### PR TITLE
Add a full summary to satisfy latest Cocoapods

### DIFF
--- a/OPActionSheet.podspec
+++ b/OPActionSheet.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |spec|
   spec.license      = { type: 'BSD' }
   spec.homepage     = 'https://github.com/mbrandonw/OPActionSheet'
   spec.authors      = { 'Brandon Williams' => 'mbw234@gmail.com' }
-  spec.summary      = ''
+  spec.summary      = 'A subclass of UIActionSheet adding some block handlers.'
   spec.source       = { :git => 'https://github.com/mbrandonw/OPActionSheet.git' }
   spec.source_files = '*.{h,m}'
   spec.requires_arc = true


### PR DESCRIPTION
With the latest Cocoapods I get this err:

```
[!] The `OPActionSheet` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `summary`.
    - WARN  | source: Git sources should specify a tag.

```
